### PR TITLE
refactor: I did some changes on how we store and get data from the GA collection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ function App() {
           <Route
             path="/admin"
             element={
-              <Protected>
+              <Protected apiKey={process.env.REACT_APP_API_KEY}>
                 <Admin />
               </Protected>
             }

--- a/src/api/firebase-config.js
+++ b/src/api/firebase-config.js
@@ -18,7 +18,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
-export const questionsRef = collection(
+export const generalAssemblyRef = collection(
   db,
   "gdsc-subprojects",
   "_",

--- a/src/context/app.context.js
+++ b/src/context/app.context.js
@@ -1,8 +1,8 @@
 import { createContext, useState } from "react";
 import { data } from "../api";
 
-import { questionsRef } from "../api/firebase-config";
-import { getDocs } from "firebase/firestore";
+import { generalAssemblyRef } from "../api/firebase-config";
+import { collection, getDocs } from "firebase/firestore";
 
 const AppContext = createContext();
 
@@ -22,13 +22,11 @@ export const AppProvider = ({ children }) => {
     });
     setQuestions(generateQuestions(data));
 
-    // commenting this for now until we get questions and answers, we're not adding dummy qna in firestore
-
-    const fetchQuestions = await getDocs(questionsRef);
-    const [_data] = fetchQuestions.docs.map((doc) => ({
-      ...doc.data(),
-      id: doc.id,
-    }));
+    // we now get questions from questions collection
+    // const _data = await fetchDocument(generalAssemblyRef);
+    // const questionsRef = collection(generalAssemblyRef, _data.id, "questions");
+    // const test = await fetchDocuments(questionsRef);
+    // console.log(test);
   };
 
   return (
@@ -70,6 +68,28 @@ function generateQuestions(q) {
       number: i + 1,
     };
   });
+}
+
+export async function fetchDocument(ref) {
+  const res = await getDocs(ref);
+  const [data] = res.docs
+    .map((doc) => ({
+      ...doc.data(),
+      id: doc.id,
+    }))
+    .filter((obj) => obj.app === "gdsc-plm-save-haribot");
+
+  return data;
+}
+
+async function fetchDocuments(ref) {
+  const res = await getDocs(ref);
+  const data = res.docs.map((doc) => ({
+    ...doc.data(),
+    id: doc.id,
+  }));
+
+  return data;
 }
 
 export default AppContext;

--- a/src/pages/admin/admin.hook.jsx
+++ b/src/pages/admin/admin.hook.jsx
@@ -1,7 +1,9 @@
 import { useRef } from "react";
 
-import { questionsRef } from "../../api/firebase-config";
-import { doc, getDocs, updateDoc } from "firebase/firestore";
+import { generalAssemblyRef } from "../../api/firebase-config";
+import { collection, addDoc } from "firebase/firestore";
+
+import { fetchDocument } from "../../context/app.context";
 
 const useAdminHook = () => {
   const formRef = useRef();
@@ -10,13 +12,9 @@ const useAdminHook = () => {
     e.preventDefault();
     document.activeElement.blur();
 
-    const fetchQuestions = await getDocs(questionsRef);
-    const [_data] = fetchQuestions.docs.map((doc) => ({
-      ...doc.data(),
-      id: doc.id,
-    }));
+    const _data = await fetchDocument(generalAssemblyRef);
 
-    const questionsDoc = doc(questionsRef, _data.id);
+    const questionsRef = collection(generalAssemblyRef, _data.id, "questions");
 
     const qTemplate = { prompt: "", choices: [], answer: "" };
 
@@ -44,9 +42,7 @@ const useAdminHook = () => {
       }
     });
 
-    await updateDoc(questionsDoc, {
-      questions: [..._data.questions, { ...qTemplate }],
-    });
+    await addDoc(questionsRef, { ...qTemplate });
   };
 
   return { formRef, handleForm };


### PR DESCRIPTION
## Description
This PR refactors the code we initially have on storing and getting data from the GA collection.

## Whats new
I added a new collection in the GA collection document called `questions` as seen here (not exposing the id):
![image](https://user-images.githubusercontent.com/70326902/199477552-23968939-34c1-41ba-8cdb-f6cab84a86a8.png)

I also updated the protected route so that we don't have to manually pass apiKey as a prop in the protected component. Just as long as you have the `.env` file, you're good to go. (to be removed on productionn/deployment)
![image](https://user-images.githubusercontent.com/70326902/199478363-752fdf5d-94df-4188-b75d-7eac84c29e52.png)
